### PR TITLE
Fix slider being able to turn off backlight

### DIFF
--- a/Managment/ReignOS.ControlCenter/Views/MainView.axaml.cs
+++ b/Managment/ReignOS.ControlCenter/Views/MainView.axaml.cs
@@ -2801,7 +2801,7 @@ public partial class MainView : UserControl
             }
 
             if (count > 0) brightness /= count;
-            displayBrightnessSlider.Value = Math.Clamp(brightness, 0, 100);
+            displayBrightnessSlider.Value = Math.Clamp(brightness, 1, 100);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
Currently backlights will turn off when the slider is set to its lowest setting, 0, setting the minimum to 1 should keep this from happening